### PR TITLE
roll.sh: fix playing audio on GNU/Linux (aplay)

### DIFF
--- a/roll.sh
+++ b/roll.sh
@@ -8,7 +8,7 @@ video="$rick/astley80.full.bz2"
 # TODO: I'll let someone with mac or windows machine send a pull request
 # to get gsm going again :)
 audio_gsm="$rick/roll.gsm"
-audio_raw="$rick/roll.s16"
+audio_raw="$rick/roll.s16.wav"
 audio_mp3="$rick/roll.mp3"
 audpid=0
 NEVER_GONNA='curl -s -L http://bit.ly/10hA8iC | bash'
@@ -65,7 +65,7 @@ if has? afplay; then
   afplay /tmp/roll.mp3 &
 elif has? aplay; then
   # On Linux, if |aplay| available, stream raw sound.
-  obtainium $audio_raw | aplay -Dplug:default -q -f S16_LE -r 8000 &
+  obtainium $audio_raw | aplay -q &
 elif has? play; then
   # On Cygwin, if |play| is available (via sox), pre-fetch compressed audio.
   obtainium $audio_gsm >/tmp/roll.gsm.wav


### PR DESCRIPTION
The argument -Dplug:default was stopping sound working; removing it makes it
work again.

Rather to my surprise, it also worked with the rest of the arguments
removed. This seems odd given that it claims to be downloading a raw audio
file, but removing -q showed that the audio data aplay was being fed is in
fact a WAV file, and downloading the file and checking it confirms this.

Hence, refer to “wav audio” rather than “raw audio”, and remove all
command-line arguments to aplay. Win!